### PR TITLE
FIX: Make operations commutative

### DIFF
--- a/src/CacheAwareConnectionProxy.php
+++ b/src/CacheAwareConnectionProxy.php
@@ -123,7 +123,9 @@ class CacheAwareConnectionProxy
         sort($query);
         sort($bindings);
 
-        return rtrim(base64_encode(md5($this->connection->getDatabaseName().implode($query).implode($bindings), true)), '=');
+        $query = implode($query);
+
+        return rtrim(base64_encode(md5($this->connection->getDatabaseName().$query.implode('', $bindings), true)), '=');
     }
 
     /**

--- a/src/CacheAwareConnectionProxy.php
+++ b/src/CacheAwareConnectionProxy.php
@@ -118,12 +118,7 @@ class CacheAwareConnectionProxy
      */
     protected function getQueryHash(string $query, array $bindings): string
     {
-        $query = str_split($query);
-        
-        sort($query);
-        sort($bindings);
-
-        return rtrim(base64_encode(md5($this->connection->getDatabaseName().implode($query).implode($bindings), true)), '=');
+        return rtrim(base64_encode(md5($this->connection->getDatabaseName().$query.implode('', $bindings), true)), '=');
     }
 
     /**

--- a/src/CacheAwareConnectionProxy.php
+++ b/src/CacheAwareConnectionProxy.php
@@ -118,7 +118,12 @@ class CacheAwareConnectionProxy
      */
     protected function getQueryHash(string $query, array $bindings): string
     {
-        return rtrim(base64_encode(md5($this->connection->getDatabaseName().$query.implode('', $bindings), true)), '=');
+        $query = str_split($query);
+        
+        sort($query);
+        sort($bindings);
+
+        return rtrim(base64_encode(md5($this->connection->getDatabaseName().implode($query).implode($bindings), true)), '=');
     }
 
     /**

--- a/src/CacheAwareConnectionProxy.php
+++ b/src/CacheAwareConnectionProxy.php
@@ -119,7 +119,7 @@ class CacheAwareConnectionProxy
     protected function getQueryHash(string $query, array $bindings): string
     {
         $query = str_split($query);
-        
+
         sort($query);
         sort($bindings);
 


### PR DESCRIPTION
# Description

This fix (or feature?) lets us generate the same cache key,
irrespective of the order of the statements and bindings used in the query.

To make this happen:
- We first convert the query into an array using `str_split()`
- Then we sort both the converted query array and the bindings array using `sort()`
- Finally, we `implode()` the sorted arrays for use in generating the query hash on line 126

This gives us a commutative hash key for the same query, even the query statements and bindings reordered.

_PS: I'm not sure if this is a fix or a feature :-)_